### PR TITLE
Fix: deck.gl link typo

### DIFF
--- a/src/data/links.yaml
+++ b/src/data/links.yaml
@@ -8,7 +8,7 @@
         url: http://vis.gl
     - item:
         label: Deck.gl
-        url: http://decl.gl
+        url: http://deck.gl
     - item:
         label: Luma.gl
         url: http://luma.gl


### PR DESCRIPTION
While navigating from [visgl](https://vis.gl/) back to [deck.gl](https://deck.gl/), it took me to [decl.gl](http://decl.gl/). There was a typo in the link and this PR fixes it.

Also closes #44 