### PR TITLE
Custom 404 to avoid unnecessary netlify function usage 

### DIFF
--- a/pages/404.module.css
+++ b/pages/404.module.css
@@ -1,0 +1,21 @@
+/* pages/404.module.css */
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  text-align: center;
+}
+
+.homeLink {
+  color: #0070f3;
+  text-decoration: none;
+  border-bottom: 1px solid #0070f3;
+  transition: all 0.2s ease;
+}
+
+.homeLink:hover {
+  color: #0366d6;
+  border-bottom-color: #0366d6;
+}

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,21 @@
+// pages/404.tsx
+import React from 'react';
+import Link from 'next/link';
+import styles from './404.module.css';
+
+const Custom404: React.FC = () => {
+  return (
+    <div className={styles.container}>
+      <h1>404 - Page Not Found</h1>
+      <p>
+        The page you are looking for might have been removed, had its name changed, or is
+        temporarily unavailable.
+      </p>
+      <Link href="/">
+        <a className={styles.homeLink}>Go to Home</a>
+      </Link>
+    </div>
+  );
+};
+
+export default Custom404;


### PR DESCRIPTION
I received this email from Netlify:
<img src=https://user-images.githubusercontent.com/351828/227377770-342be57b-0a1c-49d5-ba8c-234443ebc01b.png width=300>

And realized that we are generating unnecessary Functions usage apparently due to [this issue](https://github.com/netlify/next-runtime/discussions/1311).

![image](https://user-images.githubusercontent.com/351828/227378048-df0e3118-4145-4cde-abfb-ba9ac4dc6937.png)

Every time somebody hits an non-existant URL (and this happens all the time), a 404 page is apparently re-generated ([ISR](https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration) in Nextjs) which results in a Netlify Function call.

The hope is that adding a custom 404 should prevent this.
