### PR TITLE
fix: redirects for netlify

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,22 +10,6 @@ const nextConfig = {
       use: 'yaml-loader'
     });
     return configuration;
-  },
-  async redirects() {
-    return [
-      'react-google-maps', 
-      'react-map-gl', 
-      'math.gl', 
-      'deck.gl-community', 
-      'probe.gl'
-    ].map(project => (
-      {
-        source: `/${project}`,
-        destination: `https://visgl.github.io/${project}/`,
-        permanent: false,
-        basePath: false
-      }
-    ))
   }
 };
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,5 @@
+/react-google-maps https://visgl.github.io/react-google-maps/
+/react-map-gl https://visgl.github.io/react-map-gl/
+/math.gl https://visgl.github.io/math.gl/
+/deck.gl-community https://visgl.github.io/deck.gl-community/
+/probe.gl https://visgl.github.io/probe.gl/


### PR DESCRIPTION
Netlify doesn't seem to honor the next.js redirects. It should, but they recommend adding a `_redirects` file anyways so lets do that. https://docs.netlify.com/frameworks/next-js/runtime-v4/redirects-and-rewrites/#use-redirects-and-headers-files