### PR TITLE
Publish math.gl documentation at vis.gl/math.gl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "projects/math.gl"]
+	path = projects/math.gl
+	url = https://github.com/visgl/math.gl.git

--- a/README.md
+++ b/README.md
@@ -33,21 +33,33 @@ The static export can also host documentation built by another vis.gl project. E
 `project-sites.json` may optionally build a project, then copy its static output into a path under
 `out/`.
 
-For example, after adding the math.gl repository at `projects/math.gl`, its configuration would
-look like this:
+math.gl is included as a pinned Git submodule at `projects/math.gl`. Its configuration installs
+the submodule dependencies, builds the Docusaurus website with the canonical vis.gl URL, and
+mounts the result at `/math.gl`:
 
 ```json
 {
   "sites": [
     {
       "name": "math.gl",
-      "mountPath": "/math",
+      "mountPath": "/math.gl",
       "source": "projects/math.gl/website/build",
-      "build": {
-        "cwd": "projects/math.gl",
-        "command": "yarn",
-        "args": ["workspace", "project-website", "build"]
-      }
+      "build": [
+        {
+          "command": "git",
+          "args": ["submodule", "update", "--init", "--recursive", "--", "projects/math.gl"]
+        },
+        {
+          "cwd": "projects/math.gl",
+          "command": "yarn",
+          "args": ["install", "--immutable"]
+        },
+        {
+          "cwd": "projects/math.gl/website",
+          "command": "yarn",
+          "args": ["docusaurus", "build", "--config", "../../../project-site-configs/math.gl.mjs"]
+        }
+      ]
     }
   ]
 }
@@ -55,3 +67,4 @@ look like this:
 
 Project builds must generate URLs and assets for their configured mount path. Sources, build
 directories, and mount paths are constrained to this repository and its `out/` directory.
+`/math` permanently redirects to the canonical `/math.gl/` path.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,5 +7,5 @@ export default defineConfig([
   ...nextVitals,
   ...nextTypescript,
   prettier,
-  globalIgnores(['.next/**', 'out/**', 'next-env.d.ts'])
+  globalIgnores(['.next/**', 'out/**', 'projects/**', 'next-env.d.ts'])
 ]);

--- a/project-site-configs/math.gl.mjs
+++ b/project-site-configs/math.gl.mjs
@@ -1,0 +1,30 @@
+import {createRequire} from 'node:module';
+
+import config from '../projects/math.gl/website/docusaurus.config.js';
+
+const requireFromMathGl = createRequire(
+  new URL('../projects/math.gl/website/docusaurus.config.js', import.meta.url)
+);
+
+function resolveModuleEntry(entry, aliases = {}) {
+  if (typeof entry === 'string') {
+    return requireFromMathGl.resolve(aliases[entry] ?? entry);
+  }
+  if (Array.isArray(entry) && typeof entry[0] === 'string') {
+    return [requireFromMathGl.resolve(aliases[entry[0]] ?? entry[0]), ...entry.slice(1)];
+  }
+  return entry;
+}
+
+const mathGlConfig = {
+  ...config,
+  url: 'https://vis.gl',
+  baseUrl: '/math.gl/',
+  presets: config.presets.map(entry =>
+    resolveModuleEntry(entry, {classic: '@docusaurus/preset-classic'})
+  ),
+  plugins: config.plugins.map(entry => resolveModuleEntry(entry)),
+  themes: config.themes?.map(entry => resolveModuleEntry(entry))
+};
+
+export default mathGlConfig;

--- a/project-sites.json
+++ b/project-sites.json
@@ -1,3 +1,30 @@
 {
-  "sites": []
+  "sites": [
+    {
+      "name": "math.gl",
+      "mountPath": "/math.gl",
+      "source": "projects/math.gl/website/build",
+      "build": [
+        {
+          "command": "git",
+          "args": ["submodule", "update", "--init", "--recursive", "--", "projects/math.gl"]
+        },
+        {
+          "cwd": "projects/math.gl",
+          "command": "yarn",
+          "args": ["install", "--immutable"]
+        },
+        {
+          "cwd": "projects/math.gl/website",
+          "command": "yarn",
+          "args": [
+            "docusaurus",
+            "build",
+            "--config",
+            "../../../project-site-configs/math.gl.mjs"
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,7 @@
 /react-google-maps https://visgl.github.io/react-google-maps/
 /react-map-gl https://visgl.github.io/react-map-gl/
-/math.gl https://visgl.github.io/math.gl/
+/math /math.gl/ 301
+/math/ /math.gl/ 301
+/math/* /math.gl/:splat 301
 /deck.gl-community https://visgl.github.io/deck.gl-community/
 /probe.gl https://visgl.github.io/probe.gl/

--- a/scripts/assemble-project-sites.mjs
+++ b/scripts/assemble-project-sites.mjs
@@ -31,28 +31,32 @@ function normalizeMountPath(mountPath) {
   return mountPath.slice(1);
 }
 
-async function runBuild(rootDirectory, name, build) {
-  if (!build) {
+async function runBuild(rootDirectory, name, buildConfig) {
+  if (!buildConfig) {
     return;
   }
 
-  if (!build.command || !Array.isArray(build.args)) {
-    throw new Error(`${name} must provide a build command and argument array`);
-  }
+  const buildSteps = Array.isArray(buildConfig) ? buildConfig : [buildConfig];
 
-  const cwd = resolveInside(rootDirectory, build.cwd ?? '.', `${name} build directory`);
+  for (const [index, build] of buildSteps.entries()) {
+    if (!build.command || !Array.isArray(build.args)) {
+      throw new Error(`${name} build step ${index + 1} must provide a command and argument array`);
+    }
 
-  await new Promise((resolve, reject) => {
-    const child = spawn(build.command, build.args, {cwd, stdio: 'inherit', shell: false});
-    child.once('error', reject);
-    child.once('exit', code => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(new Error(`${name} build exited with code ${code}`));
-      }
+    const cwd = resolveInside(rootDirectory, build.cwd ?? '.', `${name} build directory`);
+
+    await new Promise((resolve, reject) => {
+      const child = spawn(build.command, build.args, {cwd, stdio: 'inherit', shell: false});
+      child.once('error', reject);
+      child.once('exit', code => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`${name} build step ${index + 1} exited with code ${code}`));
+        }
+      });
     });
-  });
+  }
 }
 
 export async function assembleProjectSites({rootDirectory = repositoryRoot, sites}) {

--- a/scripts/assemble-project-sites.test.mjs
+++ b/scripts/assemble-project-sites.test.mjs
@@ -65,6 +65,42 @@ writeFileSync('generated-site/index.html', '<h1>generated</h1>');`
   );
 });
 
+test('runs project build steps in order', async t => {
+  const rootDirectory = await createFixture(t);
+  await writeFile(
+    path.join(rootDirectory, 'prepare-project.mjs'),
+    `import {writeFileSync} from 'node:fs';
+writeFileSync('prepared.txt', 'ready');`
+  );
+  await writeFile(
+    path.join(rootDirectory, 'build-prepared-project.mjs'),
+    `import {mkdirSync, readFileSync, writeFileSync} from 'node:fs';
+const prepared = readFileSync('prepared.txt', 'utf8');
+mkdirSync('generated-site');
+writeFileSync('generated-site/index.html', \`<h1>\${prepared}</h1>\`);`
+  );
+
+  await assembleProjectSites({
+    rootDirectory,
+    sites: [
+      {
+        name: 'generated',
+        mountPath: '/generated',
+        source: 'generated-site',
+        build: [
+          {command: process.execPath, args: ['prepare-project.mjs']},
+          {command: process.execPath, args: ['build-prepared-project.mjs']}
+        ]
+      }
+    ]
+  });
+
+  assert.equal(
+    await readFile(path.join(rootDirectory, 'out', 'generated', 'index.html'), 'utf8'),
+    '<h1>ready</h1>'
+  );
+});
+
 test('rejects mount paths that escape the static output', async t => {
   const rootDirectory = await createFixture(t);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
     ]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "projects"]
 }


### PR DESCRIPTION
## Summary

- add `visgl/math.gl` as a pinned Git submodule
- initialize, install, and build the math.gl Docusaurus site as part of the vis.gl static export
- publish the complete site at the canonical `/math.gl/` path
- set canonical and Open Graph URLs to `https://vis.gl/math.gl/`
- permanently redirect `/math`, `/math/`, and nested `/math/*` URLs to `/math.gl/`
- isolate submodule sources from the vis.gl lint and TypeScript projects
- support ordered project build steps in the static-site assembler

The submodule is pinned to `visgl/math.gl@ae9aa1d`, which includes the landed dependency modernization from visgl/math.gl#125.

## Validation

- `yarn check`
- 5 project-site assembler tests pass
- vis.gl Next.js static export succeeds
- math.gl Docusaurus build succeeds and indexes 891 documents
- generated math.gl homepage uses `https://vis.gl/math.gl/` canonical and Open Graph URLs
- local HTTP checks return 200 for the math.gl homepage, stylesheet, and representative documentation page
