### PR TITLE
Refresh vis.gl website content

### DIFF
--- a/components/blog.js
+++ b/components/blog.js
@@ -17,8 +17,8 @@ const Blog = () => {
         </p>
         <br />
         <p>
-          Note that vis.gl blog posts can also be browser directly on{' '}
-          <a href="https://medium.com/@vis.gl">Medium</a>.
+          You can also browse vis.gl blog posts directly on{' '}
+          <a href="https://medium.com/vis-gl">Medium</a>.
         </p>
       </div>
 

--- a/components/hero.js
+++ b/components/hero.js
@@ -220,12 +220,12 @@ class Hero extends Component {
           }}
         >
           <div className="main">
-            {'Large scale '}
+            {'Open source tools for '}
             <em>geospatial</em>
-            {' data visualization'}
+            {' visualization'}
           </div>
           <div className="secondary">
-            Promoting Industry Collaboration through Open Source and Open Governance
+            Composable frameworks for maps, graphics, and data.
           </div>
         </div>
       </div>

--- a/components/hero.js
+++ b/components/hero.js
@@ -14,7 +14,7 @@ function createAnimationLoop() {
     createFramebuffer: true,
     onInitialize({gl}) {
       setParameters(gl, {
-        clearColor: [0, 0, 0, 1],
+        clearColor: [0, 0, 0, 0],
         clearDepth: 1,
         depthTest: true,
         depthFunc: gl.LEQUAL
@@ -199,12 +199,12 @@ class Hero extends Component {
           <canvas
             ref={this._canvas}
             id="lumagl-canvas"
-            style={{
+              style={{
               position: 'absolute',
               height: '450px',
               top: 0,
               width: '100vw',
-              background: this.state.isAnimating ? '#fff' : '#000'
+              background: 'transparent'
             }}
           />
         ) : null}

--- a/components/manifesto-section.js
+++ b/components/manifesto-section.js
@@ -157,14 +157,18 @@ export default function ManifestoSection() {
     <Sections>
       <ContainerSm>
         <TitleSection backgroundImg={'/images/logos/vis-logo.png'}>
-          Vis.gl is a suite of composable, interoperable open source geospatial visualization
-          frameworks centered around <a href="https://deck.gl">deck.gl</a>.
+          vis.gl is an open source suite of composable frameworks for geospatial visualization,
+          with projects that work independently or together around <a href="https://deck.gl">deck.gl</a>.
         </TitleSection>
       </ContainerSm>
       <ContainerSm>
         <SectionContainer>
           <SectionTitle>Contribution</SectionTitle>
           <SectionContent>
+            <Paragraph>
+              vis.gl is built in the open. Contributions are welcome from individuals, companies,
+              and research teams.
+            </Paragraph>
             <ContributorContainer>
               <ContributorSection>
                 <div className="logo-title">Lead Contributors</div>
@@ -210,9 +214,8 @@ export default function ManifestoSection() {
           <SectionTitle>Open Governance</SectionTitle>
           <SectionContent>
             <Paragraph>
-              vis.gl is under open governance, and anyone can join the open planning meetings.
-              Contributor status is available and technical steering committee membership is
-              available to major contributors.
+              vis.gl projects are developed in the open. Join planning meetings, contribute code,
+              or help shape the technical roadmap.
             </Paragraph>
             <GovernanceLogos>
               <a href="https://www.openjsf.org/">
@@ -241,7 +244,8 @@ export default function ManifestoSection() {
           <SectionTitle>Frameworks</SectionTitle>
           <SectionContent>
             <Paragraph>
-              The <Link href="/frameworks">vis.gl Framework Catalog</Link> provides an overview of the various frameworks in the vis.gl framework suite.
+              Browse the <Link href="/frameworks">vis.gl Framework Catalog</Link> to find the
+              right tools for your project. Use each framework on its own or combine them.
             </Paragraph>
             <Image
               style={{width: '100%', height: 'auto', objectFit: 'cover'}}
@@ -258,6 +262,15 @@ export default function ManifestoSection() {
         <SectionContainer>
           <SectionTitle>Releases</SectionTitle>
           <SectionContent>
+            <H3>In development</H3>
+            <Paragraph>
+              <ListTitle>math.gl 5.0</ListTitle>
+              <ListItem>
+                Prerelease development is underway. See the{' '}
+                <a href="/math.gl/docs/whats-new">release notes</a>.
+              </ListItem>
+            </Paragraph>
+            <H3>Latest stable releases</H3>
             <H3>vis.gl 9.0</H3>
             <Paragraph>
               <ListTitle>Release Date: Mar 21, 2024</ListTitle>
@@ -276,7 +289,7 @@ export default function ManifestoSection() {
 
               <ListTitle>math.gl 4.0</ListTitle>
               <ListItem>
-                <a href="https://visgl.github.io/math.gl/docs/whats-new">Release Notes</a>
+                <a href="/math.gl/docs/whats-new">Release Notes</a>
               </ListItem>
               <div style={{marginTop: 5}} />
 

--- a/components/manifesto-section.js
+++ b/components/manifesto-section.js
@@ -301,60 +301,52 @@ export default function ManifestoSection() {
         <SectionContainer>
           <SectionTitle>History</SectionTitle>
           <SectionContent>
+            <ListTitle>2026</ListTitle>
+            <List>
+              <ListItem>math.gl 5.0 entered prerelease development.</ListItem>
+              <ListItem>math.gl documentation moved to vis.gl/math.gl.</ListItem>
+            </List>
             <ListTitle>2024</ListTitle>
             <List>
               <ListItem>react-google-maps was created.</ListItem>
             </List>
             <ListTitle>2023</ListTitle>
             <List>
-              <ListItem><a href="https://deck.gl/events/new-york-summit-2023/">Open Visualization Collaborator Summit</a> hosted in New York</ListItem>
+              <ListItem><a href="https://deck.gl/events/new-york-summit-2023/">Open Visualization Collaborator Summit</a> held in New York.</ListItem>
             </List>
             <ListTitle>2022</ListTitle>
             <List>
-              <ListItem>First annual <a href="https://deck.gl/events/madrid-summit-2022/">Open Visualization Collaborator Summit</a> hosted in Madrid</ListItem>
-              <ListItem>
-                flowmap.gl joined the vis.gl project.
-              </ListItem>
-              <ListItem>
-                vis.gl and kepler.gl joined the <a href="https://openjsf.org/">OpenJS Foundation</a>.
-              </ListItem>
-              <ListItem>Urban Computing Foundation merged with the OpenJS Foundation, and formed the <a href="https://www.openvisualization.org/">Open Visualization Collaboration Group</a>.</ListItem>
+              <ListItem>First annual <a href="https://deck.gl/events/madrid-summit-2022/">Open Visualization Collaborator Summit</a> held in Madrid.</ListItem>
+              <ListItem>flowmap.gl joined the vis.gl project.</ListItem>
+              <ListItem>vis.gl and kepler.gl joined the <a href="https://openjsf.org/">OpenJS Foundation</a>.</ListItem>
+              <ListItem>Urban Computing Foundation merged with the OpenJS Foundation.</ListItem>
+              <ListItem>The <a href="https://www.openvisualization.org/">Open Visualization Collaboration Group</a> formed.</ListItem>
             </List>
             <ListTitle>2020</ListTitle>
             <List>
-              <ListItem>
-                vis.gl Open Governance meetings started, under the auspices of the Linux Foundation
-                and the UCF.
-              </ListItem>
+              <ListItem>vis.gl Open Governance meetings began under the Linux Foundation and UCF.</ListItem>
               <ListItem>Uber transferred a set of core vis.gl frameworks to the UCF.</ListItem>
               <ListItem>hubble.gl was created.</ListItem>
             </List>
             <ListTitle>2019</ListTitle>
             <List>
-              <ListItem>
-                Uber created the Urban Computing Foundation (a sub-foundation of the Linux
-                Foundation), transferring kepler.gl.
-              </ListItem>
+              <ListItem>Uber created the Urban Computing Foundation and transferred kepler.gl.</ListItem>
             </List>
             <ListTitle>2018</ListTitle>
             <List>
-              <ListItem>Uber open sourced kepler.gl</ListItem>
+              <ListItem>Uber open sourced kepler.gl.</ListItem>
               <ListItem>loaders.gl and nebula.gl were created.</ListItem>
             </List>
             <ListTitle>2017</ListTitle>
             <List>
-              <ListItem>math.gl was created.</ListItem>
-              <ListItem>probe.gl was created.</ListItem>
+              <ListItem>math.gl and probe.gl were created.</ListItem>
             </List>
             <ListTitle>2016</ListTitle>
-            <ListItem>luma.gl was created.</ListItem>
+            <List><ListItem>luma.gl was created.</ListItem></List>
             <ListTitle>2015</ListTitle>
             <List>
-              <ListItem>The core deck.gl framework was open sourced by Uber.</ListItem>
-              <ListItem>
-                The core deck.gl framework was developed by Uber to support a wide range of
-                geospatial visualization use cases across the company.
-              </ListItem>
+              <ListItem>Uber open sourced the core deck.gl framework.</ListItem>
+              <ListItem>Uber developed deck.gl for geospatial visualization.</ListItem>
             </List>
           </SectionContent>
         </SectionContainer>

--- a/content/blog.yaml
+++ b/content/blog.yaml
@@ -1,6 +1,6 @@
 - date: Apr 7, 2020
   title: 'deck.gl 8.2 moves to Open Governance'
-  blurb: The vis.gl frameworks suite is now under open governance through the Linux Foundation and the Urban Cumputing Foundation.
+  blurb: The vis.gl frameworks suite is now under open governance through the Linux Foundation and the Urban Computing Foundation.
   url: https://medium.com/vis-gl/deck-gl-8-2-moves-to-open-governance-379f147c15bb
   image: /images/blog/blog-2020-04-deck-open-governance.png
 - date: Oct 15, 2019
@@ -30,7 +30,7 @@
   image: /images/blog/blog-2019-06-kepler-jupyter.png
 - date: Jun 18, 2019
   title: Uber’s vis.gl brings glTF to geospatial data visualization
-  blurb: The Khronos glTF format brings high-quality models and pysically-based rendering to the vis.gl frameworks.
+  blurb: The Khronos glTF format brings high-quality models and physically based rendering to the vis.gl frameworks.
   url: https://medium.com/vis-gl/ubers-vis-gl-brings-gltf-to-geospatial-data-visualization-86208ddec91d
   image: /images/blog/blog-2019-06-gltf-in-geospatial-visualization.png
 - date: May 7, 2019
@@ -50,7 +50,7 @@
   image: /images/blog/blog-2019-04-kepler-dropbox-save.png
 - date: Oct 29, 2018
   title: How (sometimes) assuming the Earth is “flat” helps speed up rendering in deck.gl
-  blurb: An deep-dive into the new optimized geospatial projection engine in deck.gl v6.2
+  blurb: A deep dive into the new optimized geospatial projection engine in deck.gl v6.2
   url: https://medium.com/vis-gl/how-sometimes-assuming-the-earth-is-flat-helps-speed-up-rendering-in-deck-gl-c43b72fd6db4
   image: /images/blog/blog-2018-10-earth-is-flat.png
 - date: Oct 16, 2018
@@ -92,12 +92,12 @@
   image: /images/blog/blog-2018-04-scripting-with-deck.png
 - date: Mar 26, 2018
   title: Automatic, GPU-based object highlighting in deck.gl Layers
-  blurb: Highligting the selected object in a layer is now handled by deck.gl directly on the GPU.
+  blurb: Highlighting the selected object in a layer is now handled by deck.gl directly on the GPU.
   url: https://medium.com/vis-gl/automatic-gpu-based-object-highlighting-in-deck-gl-layers-7fe3def44c89
   image: /images/blog/blog-2018-03-gpu-based-object-highlighting.png
 - date: Feb 27, 2018
   title: 'Unfolding the Earth: Myriahedral Projections In WebGL'
-  blurb: A visual exploration of alternaive mathematical approaches to flatten the Earth sphere.
+  blurb: A visual exploration of alternative mathematical approaches to flatten the Earth sphere.
   url: https://medium.com/vis-gl/unfolding-the-earth-myriahedral-projections-in-webgl-6b2bcfd00a30
   image: /images/blog/blog-2018-02-unfolding-the-earth.png
 - date: Jul 24, 2017

--- a/content/frameworks.yaml
+++ b/content/frameworks.yaml
@@ -1,8 +1,8 @@
 frameworkGroups:
   - title:
     description: >
-      The vis.gl frameworks are designed for GPU powered geospatial visualization and analytics on the web. The frameworks are designed to be independently usable while following a common style that makes them work seamlessly together.
-      Each framework provides a number of sub-modules that export composable components such as loaders, visualization layers, and math modules that developers can cherry-pick and combine to achieve desired results.
+      The vis.gl frameworks support GPU-powered geospatial visualization and analytics on the web. Each framework can be used independently or combined through shared conventions.
+      Frameworks provide composable modules such as loaders, visualization layers, and math utilities that developers can cherry-pick and combine for their applications.
     entries:
       - name: kepler.gl
         url: https://kepler.gl
@@ -17,9 +17,9 @@ frameworkGroups:
         url: https://deck.gl
         image: /images/frameworks/deck.png
         description: >
-          Providing high-performance, GPU powered visualization layers for 
+          Providing high-performance, GPU-powered visualization layers for
           large scale geospatial data.
-          deck.gl is the corner stone of the vis.gl framework suite.
+          deck.gl is the cornerstone of the vis.gl framework suite.
           A selection of submodules provide layers for various geospatial and 3D 
           use cases.
 
@@ -35,8 +35,8 @@ frameworkGroups:
         image: /images/frameworks/loaders.png
         description: >
           A wide range of highly optimized, framework-independent loaders for geospatial, 
-          tabular and 3D file formats. Supports worker based binary data loading.
-          Supported outputs includes geospatial layers, point clouds, 3D geometries, 
+          tabular and 3D file formats. Supports worker-based binary data loading.
+          Supported outputs include geospatial layers, point clouds, 3D geometries,
           images, textures and tabular data.
 
       - name: luma.gl
@@ -71,7 +71,7 @@ frameworkGroups:
           Flowmap.gl is a flow map drawing layer for deck.gl. It can be used for visualization of geographic movement: mobility, transportation, migration, etc.
 
       - name: math.gl
-        url: https://visgl.github.io/math.gl
+        url: https://vis.gl/math.gl
         image: /images/frameworks/math.png
         description: >
           Math library focusing on 3D and geospatial math.

--- a/content/links.yaml
+++ b/content/links.yaml
@@ -5,13 +5,19 @@
       - item:
           active: true
           label: vis.gl
-          url: http://vis.gl
+          url: https://vis.gl
       - item:
           label: deck.gl
-          url: http://deck.gl
+          url: https://deck.gl
       - item:
           label: luma.gl
-          url: http://luma.gl
+          url: https://luma.gl
+      - item:
+          label: loaders.gl
+          url: https://loaders.gl
+      - item:
+          label: math.gl
+          url: https://vis.gl/math.gl/
       - item:
           label: react-map-gl
           url: https://visgl.github.io/react-map-gl/

--- a/content/meta.yaml
+++ b/content/meta.yaml
@@ -4,10 +4,12 @@
   meta:
     - item:
       name: description
-      content: Cutting edge technology meets beautiful data visualization.
+      content: >
+        Open source tools for geospatial visualization: composable frameworks for maps, graphics,
+        and data.
     - item:
       name: keywords
-      content: visualization, data visualization, webGL, OpenJS
+      content: geospatial visualization, deck.gl, luma.gl, math.gl, OpenJS
 - page: about
   path: /about
   title: About vis.gl

--- a/content/news.yaml
+++ b/content/news.yaml
@@ -87,7 +87,7 @@
   date: Nov 10, 2016
   title: Visualize Data Sets on the Web with Uber Engineering’s deck.gl Framework
   url: https://eng.uber.com/deck-gl-framework/
-  image: /images/news/deckglframework.png
+  image: /images/news/deckgl.png
 - publication: Scale Conference
   date: Sep 2, 2016
   title: Uber’s data visualization stack

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -72,7 +72,7 @@ header.showcases {
   padding-top: 164px;
   position: relative;
   width: 100vw;
-  background: #000;
+  background: url(/images/header-background.png) center / cover no-repeat #100a29;
 }
 
 #hero .main {


### PR DESCRIPTION
## Summary
- refresh the homepage value proposition, contribution, governance, frameworks, and release copy
- add loaders.gl and math.gl to the framework navigation and point math.gl to its canonical vis.gl path
- correct retained blog/news typos and repair the missing news image reference
- keep the existing blog and news archive intact

## Validation
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build`
