### PR TITLE
feat: publish probe.gl website on vis.gl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "projects/math.gl"]
 	path = projects/math.gl
 	url = https://github.com/visgl/math.gl.git
+[submodule "projects/probe.gl"]
+	path = projects/probe.gl
+	url = https://github.com/visgl/probe.gl.git

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ The static export can also host documentation built by another vis.gl project. E
 `project-sites.json` may optionally build a project, then copy its static output into a path under
 `out/`.
 
-math.gl is included as a pinned Git submodule at `projects/math.gl`. Its configuration installs
-the submodule dependencies, builds the Docusaurus website with the canonical vis.gl URL, and
-mounts the result at `/math.gl`:
+math.gl and probe.gl are included as pinned Git submodules at `projects/math.gl` and
+`projects/probe.gl`. Each project installs its own dependencies, builds its Docusaurus website
+with a canonical vis.gl URL, and mounts the result under `/math.gl` or `/probe.gl`.
 
 ```json
 {
@@ -65,6 +65,9 @@ mounts the result at `/math.gl`:
 }
 ```
 
+The `probe.gl` entry follows the same pattern and additionally installs the website workspace
+before building it, since the probe.gl monorepo keeps the website lockfile separate.
+
 Project builds must generate URLs and assets for their configured mount path. Sources, build
 directories, and mount paths are constrained to this repository and its `out/` directory.
-`/math` permanently redirects to the canonical `/math.gl/` path.
+`/math` and `/probe` permanently redirect to their canonical `/math.gl/` and `/probe.gl/` paths.

--- a/content/frameworks.yaml
+++ b/content/frameworks.yaml
@@ -77,7 +77,7 @@ frameworkGroups:
           Math library focusing on 3D and geospatial math.
 
       - name: probe.gl
-        url: https://visgl.github.io/probe.gl
+        url: https://vis.gl/probe.gl
         image: /images/frameworks/probe.png
         description: >
           JavaScript Console Logging, Instrumentation, Benchmarking and Test Utilities.

--- a/project-site-configs/probe.gl.mjs
+++ b/project-site-configs/probe.gl.mjs
@@ -1,0 +1,30 @@
+import {createRequire} from 'node:module';
+
+import config from '../projects/probe.gl/website/docusaurus.config.js';
+
+const requireFromProbeGl = createRequire(
+  new URL('../projects/probe.gl/website/docusaurus.config.js', import.meta.url)
+);
+
+function resolveModuleEntry(entry, aliases = {}) {
+  if (typeof entry === 'string') {
+    return requireFromProbeGl.resolve(aliases[entry] ?? entry);
+  }
+  if (Array.isArray(entry) && typeof entry[0] === 'string') {
+    return [requireFromProbeGl.resolve(aliases[entry[0]] ?? entry[0]), ...entry.slice(1)];
+  }
+  return entry;
+}
+
+const probeGlConfig = {
+  ...config,
+  url: 'https://vis.gl',
+  baseUrl: '/probe.gl/',
+  presets: config.presets.map(entry =>
+    resolveModuleEntry(entry, {classic: '@docusaurus/preset-classic'})
+  ),
+  plugins: config.plugins.map(entry => resolveModuleEntry(entry)),
+  themes: config.themes?.map(entry => resolveModuleEntry(entry))
+};
+
+export default probeGlConfig;

--- a/project-sites.json
+++ b/project-sites.json
@@ -25,6 +25,37 @@
           ]
         }
       ]
+    },
+    {
+      "name": "probe.gl",
+      "mountPath": "/probe.gl",
+      "source": "projects/probe.gl/website/build",
+      "build": [
+        {
+          "command": "git",
+          "args": ["submodule", "update", "--init", "--recursive", "--", "projects/probe.gl"]
+        },
+        {
+          "cwd": "projects/probe.gl",
+          "command": "yarn",
+          "args": ["install", "--immutable"]
+        },
+        {
+          "cwd": "projects/probe.gl/website",
+          "command": "yarn",
+          "args": ["install", "--immutable"]
+        },
+        {
+          "cwd": "projects/probe.gl/website",
+          "command": "yarn",
+          "args": [
+            "docusaurus",
+            "build",
+            "--config",
+            "../../../project-site-configs/probe.gl.mjs"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/public/_redirects
+++ b/public/_redirects
@@ -3,5 +3,7 @@
 /math /math.gl/ 301
 /math/ /math.gl/ 301
 /math/* /math.gl/:splat 301
+/probe /probe.gl/ 301
+/probe/ /probe.gl/ 301
+/probe/* /probe.gl/:splat 301
 /deck.gl-community https://visgl.github.io/deck.gl-community/
-/probe.gl https://visgl.github.io/probe.gl/


### PR DESCRIPTION
## Summary
- add probe.gl as a pinned project submodule
- build probe.gl with its own lockfile and current Docusaurus configuration
- publish the generated site at `/probe.gl` alongside `/math.gl`

## Validation
- `yarn check`
- assembled output contains both `out/math.gl` and `out/probe.gl`
- probe.gl Docusaurus production build succeeds

The probe.gl submodule is pinned to the merged dependency modernization commit.