### PR TITLE
feat: publish deck.gl-community docs on vis.gl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "projects/probe.gl"]
 	path = projects/probe.gl
 	url = https://github.com/visgl/probe.gl.git
+[submodule "projects/deck.gl-community"]
+	path = projects/deck.gl-community
+	url = https://github.com/visgl/deck.gl-community.git

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ The static export can also host documentation built by another vis.gl project. E
 `project-sites.json` may optionally build a project, then copy its static output into a path under
 `out/`.
 
-math.gl and probe.gl are included as pinned Git submodules at `projects/math.gl` and
-`projects/probe.gl`. Each project installs its own dependencies, builds its Docusaurus website
-with a canonical vis.gl URL, and mounts the result under `/math.gl` or `/probe.gl`.
+math.gl, probe.gl, and deck.gl-community are included as pinned Git submodules under `projects/`.
+Each project installs its own dependencies, builds its Docusaurus website with a canonical vis.gl
+URL, and mounts the result under `/math.gl`, `/probe.gl`, or `/deck.gl-community`.
 
 ```json
 {
@@ -68,6 +68,10 @@ with a canonical vis.gl URL, and mounts the result under `/math.gl` or `/probe.g
 The `probe.gl` entry follows the same pattern and additionally installs the website workspace
 before building it, since the probe.gl monorepo keeps the website lockfile separate.
 
+The `deck.gl-community` entry follows the same pattern as `probe.gl`: the monorepo and its website
+have separate lockfiles, and the website is built with a mount-specific Docusaurus configuration.
+
 Project builds must generate URLs and assets for their configured mount path. Sources, build
 directories, and mount paths are constrained to this repository and its `out/` directory.
-`/math` and `/probe` permanently redirect to their canonical `/math.gl/` and `/probe.gl/` paths.
+`/math`, `/probe`, and `/deck.gl-community` permanently redirect to their canonical project-site
+paths.

--- a/content/frameworks.yaml
+++ b/content/frameworks.yaml
@@ -83,7 +83,7 @@ frameworkGroups:
           JavaScript Console Logging, Instrumentation, Benchmarking and Test Utilities.
 
       - name: deck.gl-community
-        url: https://visgl.github.io/deck.gl-community
+        url: https://vis.gl/deck.gl-community
         image: /images/frameworks/deck.gl-community.png
         description: >
           Unofficial layers, basemaps, add-on modules for deck.gl including high-performance feature editing layers for deck.gl.

--- a/project-site-configs/deck.gl-community.mjs
+++ b/project-site-configs/deck.gl-community.mjs
@@ -1,0 +1,33 @@
+import {createRequire} from 'node:module';
+
+import config from '../projects/deck.gl-community/website/docusaurus.config.js';
+
+const requireFromDeckGlCommunity = createRequire(
+  new URL('../projects/deck.gl-community/website/docusaurus.config.js', import.meta.url)
+);
+
+function resolveModuleEntry(entry, aliases = {}) {
+  if (typeof entry === 'string') {
+    return requireFromDeckGlCommunity.resolve(aliases[entry] ?? entry);
+  }
+  if (Array.isArray(entry) && typeof entry[0] === 'string') {
+    return [
+      requireFromDeckGlCommunity.resolve(aliases[entry[0]] ?? entry[0]),
+      ...entry.slice(1)
+    ];
+  }
+  return entry;
+}
+
+const deckGlCommunityConfig = {
+  ...config,
+  url: 'https://vis.gl',
+  baseUrl: '/deck.gl-community/',
+  presets: config.presets.map(entry =>
+    resolveModuleEntry(entry, {classic: '@docusaurus/preset-classic'})
+  ),
+  plugins: config.plugins.map(entry => resolveModuleEntry(entry)),
+  themes: config.themes?.map(entry => resolveModuleEntry(entry))
+};
+
+export default deckGlCommunityConfig;

--- a/project-sites.json
+++ b/project-sites.json
@@ -56,6 +56,37 @@
           ]
         }
       ]
+    },
+    {
+      "name": "deck.gl-community",
+      "mountPath": "/deck.gl-community",
+      "source": "projects/deck.gl-community/website/build",
+      "build": [
+        {
+          "command": "git",
+          "args": ["submodule", "update", "--init", "--recursive", "--", "projects/deck.gl-community"]
+        },
+        {
+          "cwd": "projects/deck.gl-community",
+          "command": "yarn",
+          "args": ["install", "--immutable"]
+        },
+        {
+          "cwd": "projects/deck.gl-community/website",
+          "command": "yarn",
+          "args": ["install", "--immutable"]
+        },
+        {
+          "cwd": "projects/deck.gl-community/website",
+          "command": "yarn",
+          "args": [
+            "docusaurus",
+            "build",
+            "--config",
+            "../../../project-site-configs/deck.gl-community.mjs"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/public/_redirects
+++ b/public/_redirects
@@ -6,4 +6,4 @@
 /probe /probe.gl/ 301
 /probe/ /probe.gl/ 301
 /probe/* /probe.gl/:splat 301
-/deck.gl-community https://visgl.github.io/deck.gl-community/
+/deck.gl-community /deck.gl-community/ 301


### PR DESCRIPTION
## Summary

- add deck.gl-community as a pinned project-site submodule
- build its Docusaurus website with a vis.gl mount configuration
- publish it at `/deck.gl-community/` and update the framework catalog/redirect
- document the additional project-site pin and build procedure

## Validation

- `yarn check`
- verified `out/deck.gl-community/index.html` and mount-prefixed assets
