### PR TITLE
chore: disallow crawlers on mirrored project sites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,9 @@ assembled into the main static export by `project-sites.json`.
 - Start from a clean generated output directory (`rm -r out`), then run `yarn check`. This
   installs each pinned project's dependencies, builds each website with its mount configuration,
   and assembles the results under `out/`.
-- Verify `out/math.gl/index.html` and `out/probe.gl/index.html` exist and that generated asset
-  URLs use `/math.gl/` and `/probe.gl/` respectively.
+- Verify each mounted site's `index.html` and `robots.txt` exist, and that generated asset URLs use
+  its configured mount path. The current robots policy disallows all crawlers because these are
+  mirrors of upstream documentation sites.
 - Commit the gitlink update together with any `project-sites.json` or
   `project-site-configs/*.mjs` changes, then open the vis.gl PR. Do not commit build output or
   changes made inside a submodule checkout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,9 @@ assembled into the main static export by `project-sites.json`.
 - Start from a clean generated output directory (`rm -r out`), then run `yarn check`. This
   installs each pinned project's dependencies, builds each website with its mount configuration,
   and assembles the results under `out/`.
-- Verify each mounted site's `index.html` and `robots.txt` exist, and that generated asset URLs use
-  its configured mount path. The current robots policy disallows all crawlers because these are
-  mirrors of upstream documentation sites.
+- Verify the root `out/robots.txt` allows the main vis.gl pages and disallows each mirrored project
+  path. Also verify each mounted site's `index.html` and `robots.txt` exist, and that generated
+  asset URLs use its configured mount path.
 - Commit the gitlink update together with any `project-sites.json` or
   `project-site-configs/*.mjs` changes, then open the vis.gl PR. Do not commit build output or
   changes made inside a submodule checkout.

--- a/README.md
+++ b/README.md
@@ -71,8 +71,10 @@ before building it, since the probe.gl monorepo keeps the website lockfile separ
 The `deck.gl-community` entry follows the same pattern as `probe.gl`: the monorepo and its website
 have separate lockfiles, and the website is built with a mount-specific Docusaurus configuration.
 
-Each mounted project site includes a `robots.txt` file that disallows crawling. These sites mirror
-upstream documentation and should not be indexed as separate copies.
+The root `robots.txt` allows indexing of vis.gl while disallowing the `/math.gl/`, `/probe.gl/`,
+and `/deck.gl-community/` mirror trees. Each mounted project site also includes a matching
+`robots.txt` for direct access, although crawlers use the host-level file as the authoritative
+policy.
 
 Project builds must generate URLs and assets for their configured mount path. Sources, build
 directories, and mount paths are constrained to this repository and its `out/` directory.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ before building it, since the probe.gl monorepo keeps the website lockfile separ
 The `deck.gl-community` entry follows the same pattern as `probe.gl`: the monorepo and its website
 have separate lockfiles, and the website is built with a mount-specific Docusaurus configuration.
 
+Each mounted project site includes a `robots.txt` file that disallows crawling. These sites mirror
+upstream documentation and should not be indexed as separate copies.
+
 Project builds must generate URLs and assets for their configured mount path. Sources, build
 directories, and mount paths are constrained to this repository and its `out/` directory.
 `/math`, `/probe`, and `/deck.gl-community` permanently redirect to their canonical project-site

--- a/project-sites.json
+++ b/project-sites.json
@@ -4,6 +4,7 @@
       "name": "math.gl",
       "mountPath": "/math.gl",
       "source": "projects/math.gl/website/build",
+      "robotsTxt": "User-agent: *\nDisallow: /\n",
       "build": [
         {
           "command": "git",
@@ -30,6 +31,7 @@
       "name": "probe.gl",
       "mountPath": "/probe.gl",
       "source": "projects/probe.gl/website/build",
+      "robotsTxt": "User-agent: *\nDisallow: /\n",
       "build": [
         {
           "command": "git",
@@ -61,6 +63,7 @@
       "name": "deck.gl-community",
       "mountPath": "/deck.gl-community",
       "source": "projects/deck.gl-community/website/build",
+      "robotsTxt": "User-agent: *\nDisallow: /\n",
       "build": [
         {
           "command": "git",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /math.gl/
+Disallow: /probe.gl/
+Disallow: /deck.gl-community/

--- a/scripts/assemble-project-sites.mjs
+++ b/scripts/assemble-project-sites.mjs
@@ -1,5 +1,5 @@
 import {spawn} from 'node:child_process';
-import {cp, readFile, stat} from 'node:fs/promises';
+import {cp, readFile, stat, writeFile} from 'node:fs/promises';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
@@ -94,6 +94,14 @@ export async function assembleProjectSites({rootDirectory = repositoryRoot, site
       force: false,
       errorOnExist: true
     });
+
+    if (site.robotsTxt !== undefined) {
+      if (typeof site.robotsTxt !== 'string') {
+        throw new Error(`${name} robotsTxt must be a string`);
+      }
+      await writeFile(path.join(destinationDirectory, 'robots.txt'), site.robotsTxt);
+    }
+
     console.log(`Mounted ${name} at ${mountPath}`);
   }
 }

--- a/scripts/assemble-project-sites.test.mjs
+++ b/scripts/assemble-project-sites.test.mjs
@@ -65,6 +65,27 @@ writeFileSync('generated-site/index.html', '<h1>generated</h1>');`
   );
 });
 
+test('writes a configured robots.txt at the project mount', async t => {
+  const rootDirectory = await createFixture(t);
+
+  await assembleProjectSites({
+    rootDirectory,
+    sites: [
+      {
+        name: 'generated',
+        mountPath: '/generated',
+        source: 'project-build',
+        robotsTxt: 'User-agent: *\nDisallow: /\n'
+      }
+    ]
+  });
+
+  assert.equal(
+    await readFile(path.join(rootDirectory, 'out', 'generated', 'robots.txt'), 'utf8'),
+    'User-agent: *\nDisallow: /\n'
+  );
+});
+
 test('runs project build steps in order', async t => {
   const rootDirectory = await createFixture(t);
   await writeFile(


### PR DESCRIPTION
## Summary

- add `robots.txt` to the math.gl, probe.gl, and deck.gl-community mounted sites
- disallow crawling of mirrored documentation copies
- add assembly coverage and maintainer verification guidance

## Validation

- `yarn test`
- `git diff --check`
